### PR TITLE
add NLog adapter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,17 +22,17 @@ jobs:
           name: install project dependencies
           command: dotnet restore
       - run:
-          name: build CommonLogging
-          command: dotnet build src/LaunchDarkly.Logging.CommonLogging -f netstandard2.0
-      - run:
-          name: build Log4net
-          command: dotnet build src/LaunchDarkly.Logging.Log4net -f netstandard2.0
+          name: build all projects
+          command: dotnet build
       - run:
           name: run CommonLogging tests
           command: dotnet test test/LaunchDarkly.Logging.CommonLogging.Tests -f netcoreapp2.1
       - run:
           name: run Log4net tests
           command: dotnet test test/LaunchDarkly.Logging.Log4net.Tests -f netcoreapp2.1
+      - run:
+          name: run NLog tests
+          command: dotnet test test/LaunchDarkly.Logging.NLog.Tests -f netcoreapp2.1
 
   test-windows-netframework-4-5-2:
     executor:
@@ -44,14 +44,14 @@ jobs:
           name: install project dependencies
           command: dotnet restore
       - run:
-          name: build CommonLogging
-          command: dotnet build src/LaunchDarkly.Logging.CommonLogging -f net452
-      - run:
-          name: build Log4net
-          command: dotnet build src/LaunchDarkly.Logging.Log4net -f net452
+          name: build all projects
+          command: dotnet build
       - run:
           name: run CommonLogging tests
           command: dotnet test test/LaunchDarkly.Logging.CommonLogging.Tests -f net452
       - run:
           name: run Log4net tests
           command: dotnet test test/LaunchDarkly.Logging.Log4net.Tests -f net452
+      - run:
+          name: run NLog tests
+          command: dotnet test test/LaunchDarkly.Logging.NLog.Tests -f net452

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,10 @@ jobs:
           command: dotnet restore
       - run:
           name: build all projects
-          command: dotnet build
+          command: |
+            dotnet build src/LaunchDarkly.Logging.CommonLogging -f netstandard2.0
+            dotnet build src/LaunchDarkly.Logging.Log4net -f netstandard2.0
+            dotnet build src/LaunchDarkly.Logging.NLog -f netstandard2.0
       - run:
           name: run CommonLogging tests
           command: dotnet test test/LaunchDarkly.Logging.CommonLogging.Tests -f netcoreapp2.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,15 +27,13 @@ dotnet restore
 To build all targets of the project without running any tests:
 
 ```
-dotnet build src/LaunchDarkly.Logging.CommonLogging
-dotnet build src/LaunchDarkly.Logging.Log4net
+dotnet build
 ```
 
 Or, to build only the .NET Standard 2.0 target:
 
 ```
-dotnet build src/LaunchDarkly.Logging.CommonLogging -f netstandard2.0
-dotnet build src/LaunchDarkly.Logging.Log4net -f netstandard2.0
+dotnet build -f netstandard2.0
 ```
  
 ### Testing
@@ -43,13 +41,11 @@ dotnet build src/LaunchDarkly.Logging.Log4net -f netstandard2.0
 To run all unit tests, for all targets:
 
 ```
-dotnet test test/LaunchDarkly.Logging.CommonLogging.Tests
-dotnet test test/LaunchDarkly.Logging.Log4net.Tests
+dotnet test
 ```
 
 Or, to run tests only for the .NET Standard 2.0 target (using the .NET Core 2.1 runtime):
 
 ```
-dotnet test test/LaunchDarkly.Logging.CommonLogging.Tests -f netcoreapp2.1
-dotnet test test/LaunchDarkly.Logging.Log4net.Tests -f netcoreapp2.1
+dotnet test -f netcoreapp2.1
 ```

--- a/LaunchDarkly.Logging.Adapters.sln
+++ b/LaunchDarkly.Logging.Adapters.sln
@@ -9,6 +9,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LaunchDarkly.Logging.Log4ne
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LaunchDarkly.Logging.Log4net.Tests", "test\LaunchDarkly.Logging.Log4net.Tests\LaunchDarkly.Logging.Log4net.Tests.csproj", "{69E8000A-EF1D-49A9-AF1A-D95B88324222}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LaunchDarkly.Logging.NLog", "src\LaunchDarkly.Logging.NLog\LaunchDarkly.Logging.NLog.csproj", "{CAC83256-D0D3-47D2-B2DD-CC09434D80F5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LaunchDarkly.Logging.NLog.Tests", "test\LaunchDarkly.Logging.NLog.Tests\LaunchDarkly.Logging.NLog.Tests.csproj", "{2C11E267-D715-4D50-A517-E8278A3C134A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -31,5 +35,13 @@ Global
 		{69E8000A-EF1D-49A9-AF1A-D95B88324222}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{69E8000A-EF1D-49A9-AF1A-D95B88324222}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{69E8000A-EF1D-49A9-AF1A-D95B88324222}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CAC83256-D0D3-47D2-B2DD-CC09434D80F5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CAC83256-D0D3-47D2-B2DD-CC09434D80F5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CAC83256-D0D3-47D2-B2DD-CC09434D80F5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CAC83256-D0D3-47D2-B2DD-CC09434D80F5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2C11E267-D715-4D50-A517-E8278A3C134A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2C11E267-D715-4D50-A517-E8278A3C134A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2C11E267-D715-4D50-A517-E8278A3C134A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2C11E267-D715-4D50-A517-E8278A3C134A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# LaunchDarkly Logging API for .NET - Common.Logging and log4net Adapters
+# LaunchDarkly Logging API for .NET - Third-Party Logging Framework Adapters
 
 [![CircleCI](https://circleci.com/gh/launchdarkly/dotnet-logging-adapters/tree/master.svg?style=svg)](https://circleci.com/gh/launchdarkly/dotnet-logging-adapters/tree/master)
 [![Documentation](https://img.shields.io/static/v1?label=GitHub+Pages&message=reference&color=00add8)](https://launchdarkly.github.io/dotnet-logging-adapters)
 
 ## Overview
 
-These .NET packages provide integration from the [`LaunchDarkly.Logging`](https://github.com/launchdarkly/dotnet-logging) API that is used by the LaunchDarkly [.NET SDK](https://github.com/launchdarkly/dotnet-server-sdk), [Xamarin SDK](https://github.com/launchdarkly/xamarin-client-sdk), and other LaunchDarkly libraries, to the third-party logging frameworks [`Common.Logging`](https://github.com/net-commons/common-logging) and [`log4net`](https://github.com/net-commons/common-logging).
+These .NET packages provide integration from the [`LaunchDarkly.Logging`](https://github.com/launchdarkly/dotnet-logging) API that is used by the LaunchDarkly [.NET SDK](https://github.com/launchdarkly/dotnet-server-sdk), [Xamarin SDK](https://github.com/launchdarkly/xamarin-client-sdk), and other LaunchDarkly libraries, to the third-party logging frameworks [`Common.Logging`](https://github.com/net-commons/common-logging), [`log4net`](https://github.com/net-commons/common-logging), and [`NLog`](https://nlog-project.org/).
 
 LaunchDarkly tools can run on a variety of .NET platforms, including .NET Core, .NET Framework, and Xamarin. There is no single logging framework that is consistently favored across all of those. For instance, the standard in .NET Core is now `Microsoft.Extensions.Logging`, but in .NET Framework 4.5.x this is not available without bringing in .NET Core assemblies that are normally not used in .NET Framework.
 
 Earlier versions of LaunchDarkly SDKs used the `Common.Logging` framework, which provides adapters to various popular loggers. But writing the LaunchDarkly packages against such a third-party API causes inconvenience for any developer using LaunchDarkly who prefers a different framework, and it is a relatively heavyweight solution for projects that may only have simple logging requirements. The lightweight `LaunchDarkly.Logging` API, whose small feature set is geared toward the needs of LaunchDarkly SDKs, can be integrated with third-party frameworks and also provides several simple logging implementations of its own.
 
-The adapters in this repository are published as separate packages, to avoid unwanted dependencies on `Common.Logging` and `log4net` in the LaunchDarkly SDKs and in applications that do not use those frameworks.
+The adapters in this repository are published as separate packages, to avoid unwanted dependencies on `Common.Logging`, `log4net`, or `NLog` in the LaunchDarkly SDKs and in applications that do not use those frameworks.
 
 ## Usage: `Common.Logging`
 
@@ -56,6 +56,26 @@ To use the adapter:
 
     var config = Configuration.Builder("my-sdk-key")
         .Logging(LdLog4net.Adapter)
+        .Build();
+    var client = new LdClient(config);
+```
+
+## Usage: `NLog`
+
+`NLog` has a rich configuration system that allows log behavior to be controlled in many ways. The LaunchDarkly adapter does not define any specific logging behavior itself, so the actual behavior will be determined by how you have configured `NLog`.
+
+To use the adapter:
+
+1. Add the NuGet package `LaunchDarkly.Logging.NLog` to your project.
+
+2. Use the property `LaunchDarkly.Logging.LdNLog.Adapter` in any LaunchDarkly library configuration that accepts a `LaunchDarkly.Logging.ILogAdapter` object. For instance, if you are configuring the LaunchDarkly .NET SDK:
+
+```csharp
+    using LaunchDarkly.Logging;
+    using LaunchDarkly.Sdk.Server;
+
+    var config = Configuration.Builder("my-sdk-key")
+        .Logging(LdNLog.Adapter)
         .Build();
     var client = new LdClient(config);
 ```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-These .NET packages provide integration from the [`LaunchDarkly.Logging`](https://github.com/launchdarkly/dotnet-logging) API that is used by the LaunchDarkly [.NET SDK](https://github.com/launchdarkly/dotnet-server-sdk), [Xamarin SDK](https://github.com/launchdarkly/xamarin-client-sdk), and other LaunchDarkly libraries, to the third-party logging frameworks [`Common.Logging`](https://github.com/net-commons/common-logging), [`log4net`](https://github.com/net-commons/common-logging), and [`NLog`](https://nlog-project.org/).
+These .NET packages provide integration from the [`LaunchDarkly.Logging`](https://github.com/launchdarkly/dotnet-logging) API that is used by the LaunchDarkly [.NET SDK](https://github.com/launchdarkly/dotnet-server-sdk), [Xamarin SDK](https://github.com/launchdarkly/xamarin-client-sdk), and other LaunchDarkly libraries, to the third-party logging frameworks [`Common.Logging`](https://github.com/net-commons/common-logging), [`log4net`](https://logging.apache.org/log4net/), and [`NLog`](https://nlog-project.org/).
 
 LaunchDarkly tools can run on a variety of .NET platforms, including .NET Core, .NET Framework, and Xamarin. There is no single logging framework that is consistently favored across all of those. For instance, the standard in .NET Core is now `Microsoft.Extensions.Logging`, but in .NET Framework 4.5.x this is not available without bringing in .NET Core assemblies that are normally not used in .NET Framework.
 
@@ -15,7 +15,9 @@ The adapters in this repository are published as separate packages, to avoid unw
 
 ## Usage: `Common.Logging`
 
-Like `LaunchDarkly.Logging`, `Common.Logging` is a facade that can delegate to various adapters, sending the output either to some specific logging framework, or to a simple destination such as the console. Therefore, the LaunchDarkly adapter for `Common.Logging` is a facade for a facade.
+Like `LaunchDarkly.Logging`, [`Common.Logging`](https://github.com/net-commons/common-logging) is a facade that can delegate to various adapters, sending the output either to some specific logging framework, or to a simple destination such as the console. Therefore, the LaunchDarkly adapter for `Common.Logging` is a facade for a facade.
+
+The `LaunchDarkly.Logging.CommonLogging` package provides integration with `Common.Logging` version 3.4.0 and higher. You should add an explicit dependency on the [`Common.Logging` package](https://www.nuget.org/packages/Common.Logging) to your application to ensure that you are using the most recent version.
 
 `LaunchDarkly.Logging` already has adapters of its own for some of the same destinations that `Common.Logging` can delegate to. For instance, to send log output from LaunchDarkly components to the console, or to a file, or to the .NET Core `Microsoft.Extensions.Logging` API, you do not need to use `Common.Logging`; you can simply use the methods in `LaunchDarkly.Logging.Logs`. This adapter is only useful in two situations:
 
@@ -42,6 +44,8 @@ To use the adapter:
 
 ## Usage: `log4net`
 
+The `LaunchDarkly.Logging.Log4net` package provides integration with [`log4net`](https://logging.apache.org/log4net/) version 2.0.6 and higher. You should add an explicit dependency on the [`log4net` package](https://www.nuget.org/packages/log4net) to your application to ensure that you are using the most recent version.
+
 `log4net` has a rich configuration system that allows log behavior to be controlled in many ways. The LaunchDarkly adapter does not define any specific logging behavior itself, so the actual behavior will be determined by how you have configured `log4net`.
 
 To use the adapter:
@@ -61,6 +65,8 @@ To use the adapter:
 ```
 
 ## Usage: `NLog`
+
+The `LaunchDarkly.Logging.NLog` package provides integration with [`NLog`](https://nlog-project.org/) version 4.5 and higher. You should add an explicit dependency on the [`NLog` package](https://www.nuget.org/packages/NLog) to your application to ensure that you are using the most recent version.
 
 `NLog` has a rich configuration system that allows log behavior to be controlled in many ways. The LaunchDarkly adapter does not define any specific logging behavior itself, so the actual behavior will be determined by how you have configured `NLog`.
 

--- a/src/LaunchDarkly.Logging.CommonLogging/LaunchDarkly.Logging.CommonLogging.csproj
+++ b/src/LaunchDarkly.Logging.CommonLogging/LaunchDarkly.Logging.CommonLogging.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.Logging" Version="1.0.0-alpha.3" />
+    <PackageReference Include="LaunchDarkly.Logging" Version="1.0.0-alpha.4" />
     <PackageReference Include="Common.Logging" Version="3.4.1" />
   </ItemGroup>
 

--- a/src/LaunchDarkly.Logging.CommonLogging/LaunchDarkly.Logging.CommonLogging.csproj
+++ b/src/LaunchDarkly.Logging.CommonLogging/LaunchDarkly.Logging.CommonLogging.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="LaunchDarkly.Logging" Version="1.0.0-alpha.4" />
-    <PackageReference Include="Common.Logging" Version="3.4.1" />
+    <PackageReference Include="Common.Logging" Version="3.4.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/LaunchDarkly.Logging.CommonLogging/LaunchDarkly.Logging.CommonLogging.csproj
+++ b/src/LaunchDarkly.Logging.CommonLogging/LaunchDarkly.Logging.CommonLogging.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.Logging" Version="1.0.0-alpha.4" />
+    <PackageReference Include="LaunchDarkly.Logging" Version="1.0.0" />
     <PackageReference Include="Common.Logging" Version="3.4.0" />
   </ItemGroup>
 

--- a/src/LaunchDarkly.Logging.Log4net/LaunchDarkly.Logging.Log4net.csproj
+++ b/src/LaunchDarkly.Logging.Log4net/LaunchDarkly.Logging.Log4net.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.Logging" Version="1.0.0-alpha.4" />
+    <PackageReference Include="LaunchDarkly.Logging" Version="1.0.0" />
     <PackageReference Include="log4net" Version="2.0.6" />
   </ItemGroup>
 

--- a/src/LaunchDarkly.Logging.Log4net/LaunchDarkly.Logging.Log4net.csproj
+++ b/src/LaunchDarkly.Logging.Log4net/LaunchDarkly.Logging.Log4net.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="LaunchDarkly.Logging" Version="1.0.0-alpha.4" />
-    <PackageReference Include="log4net" Version="2.0.12" />
+    <PackageReference Include="log4net" Version="2.0.6" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/LaunchDarkly.Logging.Log4net/LdLog4net.cs
+++ b/src/LaunchDarkly.Logging.Log4net/LdLog4net.cs
@@ -1,4 +1,5 @@
-﻿
+﻿using System.Reflection;
+
 namespace LaunchDarkly.Logging
 {
     /// <summary>
@@ -54,7 +55,7 @@ namespace LaunchDarkly.Logging
 
         internal Log4netChannel(string name)
         {
-            _log = log4net.LogManager.GetLogger(name);
+            _log = log4net.LogManager.GetLogger(Assembly.GetCallingAssembly(), name);
         }
 
         public bool IsEnabled(LogLevel level)

--- a/src/LaunchDarkly.Logging.NLog/LaunchDarkly.Logging.NLog.csproj
+++ b/src/LaunchDarkly.Logging.NLog/LaunchDarkly.Logging.NLog.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="LaunchDarkly.Logging" Version="1.0.0-alpha.4" />
-    <PackageReference Include="NLog" Version="4.7.0" />
+    <PackageReference Include="NLog" Version="4.5.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/LaunchDarkly.Logging.NLog/LaunchDarkly.Logging.NLog.csproj
+++ b/src/LaunchDarkly.Logging.NLog/LaunchDarkly.Logging.NLog.csproj
@@ -3,10 +3,10 @@
     <Version>1.0.0-alpha.1</Version>
     <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
     <DebugType>portable</DebugType>
-    <AssemblyName>LaunchDarkly.Logging.Log4net</AssemblyName>
+    <AssemblyName>LaunchDarkly.Logging.NLog</AssemblyName>
     <OutputType>Library</OutputType>
-    <PackageId>LaunchDarkly.Logging.Log4net</PackageId>
-    <Description>LaunchDarkly logging adapter for log4net</Description>
+    <PackageId>LaunchDarkly.Logging.NLog</PackageId>
+    <Description>LaunchDarkly logging adapter for NLog</Description>
     <Copyright>Copyright 2020 LaunchDarkly</Copyright>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="LaunchDarkly.Logging" Version="1.0.0-alpha.4" />
-    <PackageReference Include="log4net" Version="2.0.12" />
+    <PackageReference Include="NLog" Version="4.7.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
@@ -25,6 +25,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\LaunchDarkly.Logging.Log4net.xml</DocumentationFile>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\LaunchDarkly.Logging.NLog.xml</DocumentationFile>
   </PropertyGroup>
 </Project>

--- a/src/LaunchDarkly.Logging.NLog/LaunchDarkly.Logging.NLog.csproj
+++ b/src/LaunchDarkly.Logging.NLog/LaunchDarkly.Logging.NLog.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.Logging" Version="1.0.0-alpha.4" />
+    <PackageReference Include="LaunchDarkly.Logging" Version="1.0.0" />
     <PackageReference Include="NLog" Version="4.5.0" />
   </ItemGroup>
 

--- a/src/LaunchDarkly.Logging.NLog/LdNLog.cs
+++ b/src/LaunchDarkly.Logging.NLog/LdNLog.cs
@@ -1,0 +1,153 @@
+﻿
+namespace LaunchDarkly.Logging
+{
+    /// <summary>
+    /// Provides integration between the LaunchDarkly SDK's logging framework and
+    /// the <c>NLog</c> framework.
+    /// </summary>
+    public static class LdNLog
+    {
+        /// <summary>
+        /// Returns an adapter for directing <c>LaunchDarkly.Logging</c> output to
+        /// <c>NLog</c>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Using this adapter will cause <c>LaunchDarkly.Logging</c> to delegate each
+        /// logger it creates to a corresponding logger created with
+        /// <c>NLog.LogManager.GetLogger</c>. What happens to the log output then is
+        /// entirely determined by the <c>NLog</c> configuration; there are no
+        /// configuration methods on the <c>Adapter</c> itself. The logger names that are
+        /// used within the <c>LaunchDarkly.Logging</c> framework are passed along as
+        /// logger names to <c>NLog</c>, so they can be used in filtering rules, etc.
+        /// </para>
+        /// <para>
+        /// The example code below shows how to configure the LaunchDarkly SDK to
+        /// use <c>NLog</c>.
+        /// </para>
+        /// </remarks>
+        /// <example>
+        /// <code>
+        ///     using LaunchDarkly.Logging;
+        ///     using LaunchDarkly.Sdk.Server;
+        ///
+        ///     var config = Configuration.Builder("my-sdk-key")
+        ///         .Logging(LdNLog.Adapter)
+        ///         .Build();
+        ///     var client = new LdClient(config);
+        /// </code>
+        /// </example>
+        /// <returns>an <c>ILogAdapter</c> that delegates to <c>NLog</c></returns>
+        public static ILogAdapter Adapter => NLogAdapter.Instance;
+    }
+
+    internal sealed class NLogAdapter : ILogAdapter
+    {
+        internal static readonly NLogAdapter Instance = new NLogAdapter();
+
+        public IChannel NewChannel(string name) => new NLogChannel(name);
+    }
+
+    internal sealed class NLogChannel : IChannel
+    {
+        private readonly NLog.Logger _log;
+
+        internal NLogChannel(string name)
+        {
+            _log = NLog.LogManager.GetLogger(name);
+        }
+
+        public bool IsEnabled(LogLevel level)
+        {
+            switch (level)
+            {
+                case LogLevel.Debug:
+                    return _log.IsDebugEnabled;
+                case LogLevel.Info:
+                    return _log.IsInfoEnabled;
+                case LogLevel.Warn:
+                    return _log.IsWarnEnabled;
+                case LogLevel.Error:
+                    return _log.IsErrorEnabled;
+                default:
+                    return false;
+            }
+        }
+
+        public void Log(LogLevel level, object message)
+        {
+            switch (level)
+            {
+                case LogLevel.Debug:
+                    _log.Debug(message);
+                    break;
+                case LogLevel.Info:
+                    _log.Info(message);
+                    break;
+                case LogLevel.Warn:
+                    _log.Warn(message);
+                    break;
+                case LogLevel.Error:
+                    _log.Error(message);
+                    break;
+            }
+        }
+
+        public void Log(LogLevel level, string format, object param)
+        {
+            switch (level)
+            {
+                case LogLevel.Debug:
+                    _log.Debug(format, param);
+                    break;
+                case LogLevel.Info:
+                    _log.Info(format, param);
+                    break;
+                case LogLevel.Warn:
+                    _log.Warn(format, param);
+                    break;
+                case LogLevel.Error:
+                    _log.Error(format, param);
+                    break;
+            }
+        }
+
+        public void Log(LogLevel level, string format, object param1, object param2)
+        {
+            switch (level)
+            {
+                case LogLevel.Debug:
+                    _log.Debug(format, param1, param2);
+                    break;
+                case LogLevel.Info:
+                    _log.Info(format, param1, param2);
+                    break;
+                case LogLevel.Warn:
+                    _log.Warn(format, param1, param2);
+                    break;
+                case LogLevel.Error:
+                    _log.Error(format, param1, param2);
+                    break;
+            }
+        }
+
+        public void Log(LogLevel level, string format, params object[] allParams)
+        {
+            switch (level)
+            {
+                case LogLevel.Debug:
+                    _log.Debug(format, allParams);
+                    break;
+                case LogLevel.Info:
+                    _log.Info(format, allParams);
+                    break;
+                case LogLevel.Warn:
+                    _log.Warn(format, allParams);
+                    break;
+                case LogLevel.Error:
+                    _log.Error(format, allParams);
+                    break;
+            }
+        }
+    }
+}

--- a/test/LaunchDarkly.Logging.NLog.Tests/LaunchDarkly.Logging.NLog.Tests.csproj
+++ b/test/LaunchDarkly.Logging.NLog.Tests/LaunchDarkly.Logging.NLog.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.1;net452</TargetFrameworks>
+    <AssemblyName>LaunchDarkly.Logging.NLog.Tests</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\LaunchDarkly.Logging.NLog\LaunchDarkly.Logging.NLog.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/LaunchDarkly.Logging.NLog.Tests/LdNLogTest.cs
+++ b/test/LaunchDarkly.Logging.NLog.Tests/LdNLogTest.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using Xunit;
+
+namespace LaunchDarkly.Logging.Tests
+{
+    public class LdNLogTest
+    {
+        [Fact]
+        public void TestAdapter()
+        {
+            var nLogCapture = new NLog.Targets.MemoryTarget();
+            nLogCapture.Layout = "${level}: ${message}";
+            NLog.Config.SimpleConfigurator.ConfigureForTargetLogging(nLogCapture, NLog.LogLevel.Debug);
+
+            var ourAdapter = LdNLog.Adapter;
+            var logger1 = ourAdapter.Logger("things");
+            var logger2 = logger1.SubLogger("stuff");
+
+            logger1.Debug("d0");
+            logger1.Debug("d1,{0}", "a");
+            logger1.Debug("d2,{0},{1}", "a", "b");
+            logger1.Debug("d3,{0},{1},{2}", "a", "b", "c");
+            logger1.Info("i0");
+            logger1.Info("i1,{0}", "a");
+            logger1.Info("i2,{0},{1}", "a", "b");
+            logger1.Info("i3,{0},{1},{2}", "a", "b", "c");
+            logger1.Warn("w0");
+            logger1.Warn("w1,{0}", "a");
+            logger1.Warn("w2,{0},{1}", "a", "b");
+            logger1.Warn("w3,{0},{1},{2}", "a", "b", "c");
+            logger1.Error("e0");
+            logger1.Error("e1,{0}", "a");
+            logger1.Error("e2,{0},{1}", "a", "b");
+            logger1.Error("e3,{0},{1},{2}", "a", "b", "c");
+            logger2.Warn("goodbye");
+
+            Assert.Collection(nLogCapture.Logs,
+                ExpectEvent("things", LogLevel.Debug, "d0"),
+                ExpectEvent("things", LogLevel.Debug, "d1,a"),
+                ExpectEvent("things", LogLevel.Debug, "d2,a,b"),
+                ExpectEvent("things", LogLevel.Debug, "d3,a,b,c"),
+                ExpectEvent("things", LogLevel.Info, "i0"),
+                ExpectEvent("things", LogLevel.Info, "i1,a"),
+                ExpectEvent("things", LogLevel.Info, "i2,a,b"),
+                ExpectEvent("things", LogLevel.Info, "i3,a,b,c"),
+                ExpectEvent("things", LogLevel.Warn, "w0"),
+                ExpectEvent("things", LogLevel.Warn, "w1,a"),
+                ExpectEvent("things", LogLevel.Warn, "w2,a,b"),
+                ExpectEvent("things", LogLevel.Warn, "w3,a,b,c"),
+                ExpectEvent("things", LogLevel.Error, "e0"),
+                ExpectEvent("things", LogLevel.Error, "e1,a"),
+                ExpectEvent("things", LogLevel.Error, "e2,a,b"),
+                ExpectEvent("things", LogLevel.Error, "e3,a,b,c"),
+                ExpectEvent("things.stuff", LogLevel.Warn, "goodbye")
+                );
+        }
+
+        private Action<string> ExpectEvent(string loggerName,
+            LogLevel level, string message)
+        {
+            return line =>
+            {
+                Assert.Equal(string.Format("{0}: {1}", level, message), line);
+            };
+        }
+    }
+}


### PR DESCRIPTION
This should be pretty self-explanatory. NLog is another popular framework with similar capabilities to log4net.

I also made some dependency changes and readme updates in this PR to clarify that there's a _minimum_ version of each framework that our adapters work with. This is determined not just by breaking API changes in major versions, but also by target framework compatibility changes that the maintainers have made in minor or even patch versions— for instance, if a framework originally supported only .NET Framework, and then added .NET Standard support in a later version, the later version is our minimum because the SDK must support .NET Standard. So, I've set the dependencies here in our code to the minimum compatible versions, and clarified in the readme that it's up to the application to select whatever more recent version they want to use.