### PR TITLE
update to use new docs structure + use latest parent package release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,8 +14,8 @@ We encourage pull requests and other contributions from the community. Before su
  
 ### Prerequisites
 
-This project has two targets: .NET Standard 2.0 and .NET Framework 4.5.2. In Windows, you can build both; outside of Windows, you will need to [download .NET Core and follow the instructions](https://dotnet.microsoft.com/download) (make sure you have 2.0 or higher) and can only build the .NET Standard target.
- 
+To set up your SDK build time environment, you must [download .NET development tools and follow the instructions](https://dotnet.microsoft.com/download). .NET 5.0 is preferred, since the .NET 5.0 tools are able to build for all supported target platforms.
+
 ### Building
  
 To install all required packages:

--- a/README.md
+++ b/README.md
@@ -10,84 +10,7 @@
 
 These .NET packages provide integration from the [`LaunchDarkly.Logging`](https://github.com/launchdarkly/dotnet-logging) API that is used by the LaunchDarkly [.NET SDK](https://github.com/launchdarkly/dotnet-server-sdk), [Xamarin SDK](https://github.com/launchdarkly/xamarin-client-sdk), and other LaunchDarkly libraries, to the third-party logging frameworks [`Common.Logging`](https://github.com/net-commons/common-logging), [`log4net`](https://logging.apache.org/log4net/), and [`NLog`](https://nlog-project.org/).
 
-LaunchDarkly tools can run on a variety of .NET platforms, including .NET Core, .NET Framework, and Xamarin. There is no single logging framework that is consistently favored across all of those. For instance, the standard in .NET Core is now `Microsoft.Extensions.Logging`, but in .NET Framework 4.5.x this is not available without bringing in .NET Core assemblies that are normally not used in .NET Framework.
-
-Earlier versions of LaunchDarkly SDKs used the `Common.Logging` framework, which provides adapters to various popular loggers. But writing the LaunchDarkly packages against such a third-party API causes inconvenience for any developer using LaunchDarkly who prefers a different framework, and it is a relatively heavyweight solution for projects that may only have simple logging requirements. The lightweight `LaunchDarkly.Logging` API, whose small feature set is geared toward the needs of LaunchDarkly SDKs, can be integrated with third-party frameworks and also provides several simple logging implementations of its own.
-
-The adapters in this repository are published as separate packages, to avoid unwanted dependencies on `Common.Logging`, `log4net`, or `NLog` in the LaunchDarkly SDKs and in applications that do not use those frameworks.
-
-## Usage: `Common.Logging`
-
-Like `LaunchDarkly.Logging`, [`Common.Logging`](https://github.com/net-commons/common-logging) is a facade that can delegate to various adapters, sending the output either to some specific logging framework, or to a simple destination such as the console. Therefore, the LaunchDarkly adapter for `Common.Logging` is a facade for a facade.
-
-The `LaunchDarkly.Logging.CommonLogging` package provides integration with `Common.Logging` version 3.4.0 and higher. You should add an explicit dependency on the [`Common.Logging` package](https://www.nuget.org/packages/Common.Logging) to your application to ensure that you are using the most recent version.
-
-`LaunchDarkly.Logging` already has adapters of its own for some of the same destinations that `Common.Logging` can delegate to. For instance, to send log output from LaunchDarkly components to the console, or to a file, or to the .NET Core `Microsoft.Extensions.Logging` API, you do not need to use `Common.Logging`; you can simply use the methods in `LaunchDarkly.Logging.Logs`. This adapter is only useful in two situations:
-
-* You have an application that is already using `Common.Logging` (such as an application that was built with an older version of the LaunchDarkly .NET SDK or Xamarin SDK, which previously always logged to `Common.Logging`).
-* Or, you want to use some destination that `Common.Logging` already integrates with and `LaunchDarkly.Logging` currently does not.
-
-To use the adapter:
-
-1. Add the NuGet package `LaunchDarkly.Logging.CommonLogging` to your project.
-
-2. Use the property `LaunchDarkly.Logging.LdCommonLogging.Adapter` in any LaunchDarkly library configuration that accepts a `LaunchDarkly.Logging.ILogAdapter` object. For instance, if you are configuring the LaunchDarkly .NET SDK:
-
-```csharp
-    using LaunchDarkly.Logging;
-    using LaunchDarkly.Sdk.Server;
-
-    var config = Configuration.Builder("my-sdk-key")
-        .Logging(LdCommonLogging.Adapter)
-        .Build();
-    var client = new LdClient(config);
-```
-
-`LdCommonLogging.Adapter` does not have any configuration methods of its own; what happens to the log output is entirely determined by the `Common.Logging` configuration.
-
-## Usage: `log4net`
-
-The `LaunchDarkly.Logging.Log4net` package provides integration with [`log4net`](https://logging.apache.org/log4net/) version 2.0.6 and higher. You should add an explicit dependency on the [`log4net` package](https://www.nuget.org/packages/log4net) to your application to ensure that you are using the most recent version.
-
-`log4net` has a rich configuration system that allows log behavior to be controlled in many ways. The LaunchDarkly adapter does not define any specific logging behavior itself, so the actual behavior will be determined by how you have configured `log4net`.
-
-To use the adapter:
-
-1. Add the NuGet package `LaunchDarkly.Logging.Log4net` to your project.
-
-2. Use the property `LaunchDarkly.Logging.LdLog4net.Adapter` in any LaunchDarkly library configuration that accepts a `LaunchDarkly.Logging.ILogAdapter` object. For instance, if you are configuring the LaunchDarkly .NET SDK:
-
-```csharp
-    using LaunchDarkly.Logging;
-    using LaunchDarkly.Sdk.Server;
-
-    var config = Configuration.Builder("my-sdk-key")
-        .Logging(LdLog4net.Adapter)
-        .Build();
-    var client = new LdClient(config);
-```
-
-## Usage: `NLog`
-
-The `LaunchDarkly.Logging.NLog` package provides integration with [`NLog`](https://nlog-project.org/) version 4.5 and higher. You should add an explicit dependency on the [`NLog` package](https://www.nuget.org/packages/NLog) to your application to ensure that you are using the most recent version.
-
-`NLog` has a rich configuration system that allows log behavior to be controlled in many ways. The LaunchDarkly adapter does not define any specific logging behavior itself, so the actual behavior will be determined by how you have configured `NLog`.
-
-To use the adapter:
-
-1. Add the NuGet package `LaunchDarkly.Logging.NLog` to your project.
-
-2. Use the property `LaunchDarkly.Logging.LdNLog.Adapter` in any LaunchDarkly library configuration that accepts a `LaunchDarkly.Logging.ILogAdapter` object. For instance, if you are configuring the LaunchDarkly .NET SDK:
-
-```csharp
-    using LaunchDarkly.Logging;
-    using LaunchDarkly.Sdk.Server;
-
-    var config = Configuration.Builder("my-sdk-key")
-        .Logging(LdNLog.Adapter)
-        .Build();
-    var client = new LdClient(config);
-```
+For more information and examples, see the [API documentation](https://launchdarkly.github.io/dotnet-logging-adapters).
 
 ## Supported .NET versions
 
@@ -130,4 +53,3 @@ Public Key Token: d9182e4b0afd33e7
     * [docs.launchdarkly.com](https://docs.launchdarkly.com/  "LaunchDarkly Documentation") for our documentation and SDK reference guides
     * [apidocs.launchdarkly.com](https://apidocs.launchdarkly.com/  "LaunchDarkly API Documentation") for our API documentation
     * [blog.launchdarkly.com](https://blog.launchdarkly.com/  "LaunchDarkly Blog Documentation") for the latest product updates
-    * [Feature Flagging Guide](https://github.com/launchdarkly/featureflags/  "Feature Flagging Guide") for best practices and strategies

--- a/docs-src/index.md
+++ b/docs-src/index.md
@@ -1,0 +1,80 @@
+These .NET packages provide integration from the [`LaunchDarkly.Logging`](https://launchdarkly.github.io/dotnet-logging) API that is used by the LaunchDarkly [.NET SDK](https://github.com/launchdarkly/dotnet-server-sdk), [Xamarin SDK](https://github.com/launchdarkly/xamarin-client-sdk), and other LaunchDarkly libraries, to the third-party logging frameworks [`Common.Logging`](https://github.com/net-commons/common-logging), [`log4net`](https://logging.apache.org/log4net/), and [`NLog`](https://nlog-project.org/).
+
+* [**`Common.Logging`**](https://github.com/net-commons/common-logging)
+* [**`log4net`**](https://logging.apache.org/log4net/)
+* [**`NLog`**](https://nlog-project.org/).
+
+The adapters in this repository are published as separate NuGet packages, to avoid unwanted dependencies on `Common.Logging`, `log4net`, or `NLog` in the LaunchDarkly SDKs and in applications that do not use those frameworks.
+
+## Using **Common.Logging**
+
+The **<xref:LaunchDarkly.Logging.LdCommonLogging>** adapter is provided by the NuGet package [**`LaunchDarkly.Logging.CommonLogging`**](https://nuget.org/packages/LaunchDarkly.Logging.CommonLogging). It provides integration with [`Common.Logging`](https://github.com/net-commons/common-logging) version 3.4.0 and higher.
+
+Like `LaunchDarkly.Logging`, `Common.Logging` is a facade that can delegate to various adapters, sending the output either to some specific logging framework, or to a simple destination such as the console. Therefore, the LaunchDarkly adapter for `Common.Logging` is a facade for a facade.
+
+`LaunchDarkly.Logging` already has adapters of its own for some of the same destinations that `Common.Logging` can delegate to. For instance, to send log output from LaunchDarkly components to the console, or to a file, or to the .NET Core `Microsoft.Extensions.Logging` API, you do not need to use `Common.Logging`; you can simply use the methods in `LaunchDarkly.Logging.Logs`. This adapter is only useful in two situations:
+
+* You have an application that is already using `Common.Logging` (such as an application that was built with an older version of the LaunchDarkly .NET SDK or Xamarin SDK, which previously always logged to `Common.Logging`).
+* Or, you want to use some destination that `Common.Logging` already integrates with and `LaunchDarkly.Logging` currently does not.
+
+To use the adapter:
+
+1. Add the NuGet package `LaunchDarkly.Logging.CommonLogging` to your project. Make sure you also have a dependency on a compatible version of [`Common.Logging`](https://nuget.org/packages/Common.Logging).
+
+2. Use the property [**LdCommonLogging.Adapter**](xref:LaunchDarkly.Logging.LdCommonLogging.Adapter) in any LaunchDarkly library configuration that accepts a `LaunchDarkly.Logging.ILogAdapter` object. For instance, if you are configuring the LaunchDarkly .NET SDK:
+
+```csharp
+    using LaunchDarkly.Logging;
+    using LaunchDarkly.Sdk.Server;
+
+    var config = Configuration.Builder("my-sdk-key")
+        .Logging(LdCommonLogging.Adapter)
+        .Build();
+    var client = new LdClient(config);
+```
+
+`LdCommonLogging.Adapter` does not have any configuration methods of its own; what happens to the log output is entirely determined by the `Common.Logging` configuration.
+
+## Using **log4net**
+
+The **<xref:LaunchDarkly.Logging.LdLog4net>** adapter is provided by the NuGet package [**`LaunchDarkly.Logging.Log4net`**](https://nuget.org/packages/LaunchDarkly.Logging.Log4net). It provides integration with [`log4net`](https://logging.apache.org/log4net/) version 2.0.6 and higher.
+
+`log4net` has a rich configuration system that allows log behavior to be controlled in many ways. The LaunchDarkly adapter does not define any specific logging behavior itself, so the actual behavior will be determined by how you have configured `log4net`.
+
+To use the adapter:
+
+1. Add the NuGet package `LaunchDarkly.Logging.Log4net` to your project. Make sure you also have a dependency on a compatible version of [`log4net`](https://nuget.org/packages/log4net).
+
+2. Use the property [**LdLog4net.Adapter**](xref:LaunchDarkly.Logging.LdLog4net.Adapter) in any LaunchDarkly library configuration that accepts a `LaunchDarkly.Logging.ILogAdapter` object. For instance, if you are configuring the LaunchDarkly .NET SDK:
+
+```csharp
+    using LaunchDarkly.Logging;
+    using LaunchDarkly.Sdk.Server;
+
+    var config = Configuration.Builder("my-sdk-key")
+        .Logging(LdLog4net.Adapter)
+        .Build();
+    var client = new LdClient(config);
+```
+
+## Using **NLog**
+
+The **<xref:LaunchDarkly.Logging.LdNLog>** adapter is provided by the NuGet package [**`LaunchDarkly.Logging.NLog`**](https://nuget.org/packages/LaunchDarkly.LoggingNLog). It provides integration with [`NLog`](https://nlog-project.org/) version 4.5 and higher.
+
+`NLog` has a rich configuration system that allows log behavior to be controlled in many ways. The LaunchDarkly adapter does not define any specific logging behavior itself, so the actual behavior will be determined by how you have configured `NLog`.
+
+To use the adapter:
+
+1. Add the NuGet package `LaunchDarkly.Logging.NLog` to your project. Make sure you also have a dependency on a compatible version of [`NLog`](https://nuget.org/packages/NLog).
+
+2. Use the property [**LdNLog.Adapter**](xref:LaunchDarkly.Logging.LdNLog.Adapter) in any LaunchDarkly library configuration that accepts a `LaunchDarkly.Logging.ILogAdapter` object. For instance, if you are configuring the LaunchDarkly .NET SDK:
+
+```csharp
+    using LaunchDarkly.Logging;
+    using LaunchDarkly.Sdk.Server;
+
+    var config = Configuration.Builder("my-sdk-key")
+        .Logging(LdNLog.Adapter)
+        .Build();
+    var client = new LdClient(config);
+```

--- a/docs-src/index.md
+++ b/docs-src/index.md
@@ -1,9 +1,5 @@
 These .NET packages provide integration from the [`LaunchDarkly.Logging`](https://launchdarkly.github.io/dotnet-logging) API that is used by the LaunchDarkly [.NET SDK](https://github.com/launchdarkly/dotnet-server-sdk), [Xamarin SDK](https://github.com/launchdarkly/xamarin-client-sdk), and other LaunchDarkly libraries, to the third-party logging frameworks [`Common.Logging`](https://github.com/net-commons/common-logging), [`log4net`](https://logging.apache.org/log4net/), and [`NLog`](https://nlog-project.org/).
 
-* [**`Common.Logging`**](https://github.com/net-commons/common-logging)
-* [**`log4net`**](https://logging.apache.org/log4net/)
-* [**`NLog`**](https://nlog-project.org/).
-
 The adapters in this repository are published as separate NuGet packages, to avoid unwanted dependencies on `Common.Logging`, `log4net`, or `NLog` in the LaunchDarkly SDKs and in applications that do not use those frameworks.
 
 ## Using **Common.Logging**

--- a/src/LaunchDarkly.Logging.CommonLogging/LaunchDarkly.Logging.CommonLogging.csproj
+++ b/src/LaunchDarkly.Logging.CommonLogging/LaunchDarkly.Logging.CommonLogging.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.Logging" Version="[1.0.0,]" />
+    <PackageReference Include="LaunchDarkly.Logging" Version="[1.0.1,]" />
     <PackageReference Include="Common.Logging" Version="[3.4.0,4.0.0)" />
   </ItemGroup>
 

--- a/src/LaunchDarkly.Logging.NLog/LaunchDarkly.Logging.NLog.csproj
+++ b/src/LaunchDarkly.Logging.NLog/LaunchDarkly.Logging.NLog.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.Logging" Version="[1.0.0,]" />
+    <PackageReference Include="LaunchDarkly.Logging" Version="[1.0.1,]" />
     <PackageReference Include="NLog" Version="[4.5.0,5.0.0)" />
   </ItemGroup>
 


### PR DESCRIPTION
This moves the main API doc content out of the obsolete `NamespaceDoc.cs` file into the new structure we use with DocFX, and generally improves some of the readme content. You can see a temporary build of the docs [here](https://41-325445150-gh.circle-artifacts.com/0/artifacts/index.html).