### PR TITLE
fix: add release-please version markers to csproj

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
       "include-v-in-tag": false,
       "include-component-in-tag": false,
       "extra-files": [
+        "src/LaunchDarkly.Logging.CommonLogging/LaunchDarkly.Logging.CommonLogging.csproj",
         "PROVENANCE.md"
       ]
     }

--- a/src/LaunchDarkly.Logging.CommonLogging/LaunchDarkly.Logging.CommonLogging.csproj
+++ b/src/LaunchDarkly.Logging.CommonLogging/LaunchDarkly.Logging.CommonLogging.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!--x-release-please-start-version-->
     <Version>1.0.1</Version>
+    <!--x-release-please-end-->
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
 
     <DebugType>portable</DebugType>


### PR DESCRIPTION
## Summary

release-please doesn't update the `<Version>` in the `.csproj` because the file is missing from `extra-files` and lacks `x-release-please-start-version` / `x-release-please-end` markers. This means the NuGet package would be built with the old version on every release, and `dotnet nuget push` would fail since that version already exists on NuGet.

Adds the csproj to `extra-files` in `release-please-config.json` and wraps the `<Version>` tag with release-please markers — matching how the NLog and MS logging adapters are configured.

Link to Devin session: https://app.devin.ai/sessions/746778111964463bbcfa2ddded90cb85
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release automation and version metadata only; no runtime or application logic changes.
> 
> **Overview**
> Wires **release-please** into the **Common.Logging** adapter so automated releases bump the NuGet **`<Version>`** in `LaunchDarkly.Logging.CommonLogging.csproj`.
> 
> The csproj is added to **`extra-files`** in `release-please-config.json`, and the version element is wrapped with **`x-release-please-start-version`** / **`x-release-please-end`** markers (same pattern as `PROVENANCE.md` and the other logging adapters). Without this, release builds could keep publishing **1.0.1** and **`dotnet nuget push`** would fail on duplicate versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 433bfc58a82c99eb73479d7f3e903b5cb07db239. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->